### PR TITLE
Add a failing test case and better error message

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -819,7 +819,15 @@ getColumn getter tableName' [PersistText columnName, PersistText isNullable, Per
           [] -> return Nothing
           [[PersistText table, PersistText constraint]] ->
             return $ Just (DBName table, DBName constraint)
-          _ -> error "Postgresql.getColumn: error fetching constraints"
+          xs ->
+            error $ mconcat
+              [ "Postgresql.getColumn: error fetching constraints. Expected a single table and a single constraint for table: "
+              , T.unpack (unDBName tableName')
+              , " and a column: "
+              , T.unpack (unDBName cname)
+              , " but got: "
+              , show xs
+              ]
     d' = case defaultValue of
             PersistNull   -> Right Nothing
             PersistText t -> Right $ Just t

--- a/persistent-postgresql/test/CustomConstraintTest.hs
+++ b/persistent-postgresql/test/CustomConstraintTest.hs
@@ -23,6 +23,12 @@ CustomConstraint1
 CustomConstraint2
     cc_id CustomConstraint1Id constraint=custom_constraint
     deriving Show
+
+CustomConstraint3
+    -- | This will lead to a constraint with the name custom_constraint3_cc_id1_fkey
+    cc_id1 CustomConstraint1Id
+    cc_id2 CustomConstraint1Id
+    deriving Show
 |]
 
 specs :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
@@ -51,3 +57,10 @@ specs runDb = do
                                       ,PersistText "custom_constraint"]
       liftIO $ 1 @?= (exists :: Int)
 
+    it "allows multiple constraints on a single column" $ runDb $ do
+      runMigration customConstraintMigrate
+      -- | Here we add another foreign key on the same column where the default one already exists. In practice, this could be a compound key with another field.
+      rawExecute "ALTER TABLE \"custom_constraint3\" ADD CONSTRAINT \"extra_constraint\" FOREIGN KEY(\"cc_id1\") REFERENCES \"custom_constraint1\"(\"id\")" []
+      -- | This is where the error is thrown in `getColumn`
+      _ <- getMigration customConstraintMigrate
+      pure ()


### PR DESCRIPTION
This commit adds a (failing) test case for when multiple foreign key
constraints exist on a single column.

Before submitting your PR, check that you've:

(I didn't bump any version numbers here, I figured that should happen in the larger PR back to trunk)